### PR TITLE
fix parent span id

### DIFF
--- a/pkg/protocol/http.go
+++ b/pkg/protocol/http.go
@@ -386,17 +386,18 @@ func (nr *NetHTTPRequest) StartRequest() {
 			)
 		}
 	} else {
+		span = opentracing.StartSpan(
+			operation,
+			opentracing.ChildOf(wireContext),
+		)
+
 		if nr.isInbound {
-			context := wireContext.(jaeger.SpanContext)
+			context := span.Context().(jaeger.SpanContext)
 			nr.tracingContextMapping.SetDefault(
 				httpRequest.Header.Get(httpConfig.RequestIdHeaderName),
 				context,
 			)
 		}
-		span = opentracing.StartSpan(
-			operation,
-			opentracing.ChildOf(wireContext),
-		)
 	}
 
 	nr.spans.Push(span)


### PR DESCRIPTION
**The problem**
`wireContext` always has a root context. It leads to wrong `ChildOf` reference (nested traces has root value instead of a parent.

**Solution**
Make a span first and use it in cache instead of root span.